### PR TITLE
Added Apache2 ( httpd ) auto service starting on arch linux

### DIFF
--- a/autosploit/main.py
+++ b/autosploit/main.py
@@ -31,8 +31,6 @@ def main():
     logo()
     info("welcome to autosploit, give us a little bit while we configure")
     misc_info("checking for disabled services")
-    # according to ps aux, postgre and apache2 are the names of the services
-    #SERVICE_NAMES = ("postgres", "apache2")
     for service in list(SERVICE_NAMES):
         while not check_services(service):
             choice = prompt(

--- a/autosploit/main.py
+++ b/autosploit/main.py
@@ -18,7 +18,8 @@ from lib.settings import (
     cmdline,
     EXPLOIT_FILES_PATH,
     START_APACHE_PATH,
-    START_POSTGRESQL_PATH
+    START_POSTGRESQL_PATH,
+    SERVICE_NAMES
 )
 from lib.jsonize import load_exploits
 
@@ -31,12 +32,12 @@ def main():
     info("welcome to autosploit, give us a little bit while we configure")
     misc_info("checking for disabled services")
     # according to ps aux, postgre and apache2 are the names of the services
-    service_names = ("postgres", "apache2")
-    for service in list(service_names):
+    #SERVICE_NAMES = ("postgres", "apache2")
+    for service in list(SERVICE_NAMES):
         while not check_services(service):
             choice = prompt(
                 "it appears that service {} is not enabled, would you like us to enable it for you[y/N]".format(
-                    service.title()
+                    service[0].title()
                 )
             )
             if choice.lower().startswith("y"):

--- a/etc/scripts/start_apache.sh
+++ b/etc/scripts/start_apache.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-sudo service apache2 start > /dev/null 2>&1
+distribution=`uname -r`
+archstring="ARCH"
+
+if [[ $distribution =~ $archstring ]] # compare if we are under arch
+then # if yes, launch apachectl
+	sudo apachectl > /dev/null 2>&1
+else # if not, launch it the debian way
+	sudo service apache2 start > /dev/null 2>&1
+fi

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -67,6 +67,8 @@ AUTOSPLOIT_TERM_OPTS = {
     99: "quit"
 }
 
+SERVICE_NAMES = (["postgres"], ["apache2", "httpd"])
+
 stop_animation = False
 
 
@@ -93,8 +95,9 @@ def check_services(service_name):
         running_proc = psutil.Process(pid)
         all_processes.add(" ".join(running_proc.cmdline()).strip())
     for proc in list(all_processes):
-        if service_name in proc:
-            return True
+        for service in service_name:
+            if service in proc:
+                return True
     return False
 
 


### PR DESCRIPTION
This commit allow permit autosploit to automatically launch Apache2 on arch linux.
`start_apache.sh`: check distribution, and if arch, launch apache the arch way. Else, launch it the debian way.
`main.py`: migrated service_names to SERVICE_NAMES in settings.py
`settings.py`: multiple names for the same service, and migrated SERVICE_NAMES

There are others error related to ruby and msfconsole that I'll fix in a dedicated branch on my fork.
