### PR TITLE
Fixed a strange ruby bug: when the python program queryed for a msfco…

### DIFF
--- a/lib/term/terminal.py
+++ b/lib/term/terminal.py
@@ -176,7 +176,6 @@ class AutoSploitTerminal(object):
             msf_path = lib.output.prompt(
                 "it appears that MSF is not in your PATH, provide the full path to msfconsole"
             )
-            ruby_exec = True
         lib.output.info(
             "you will need to do some configuration to MSF.\n"
             "please keep in mind that sending connections back to "


### PR DESCRIPTION
…nsole path, it automatically settep ruby_exec to True, which is not a desired behaviour since it overwrites the user input.

This line was causing a bug in my installation ( where msfconsole is not automatically detected ), where ruby was used to run `/usr/bin/msfconsole` but, as you can see just under this, `/usr/bin/msfconsole` is a shell script.
```bash
╭─[camille::bzharch]
╰─[11:36:22]> file /usr/bin/msfconsole
/usr/bin/msfconsole: POSIX shell script, ASCII text executable
```
I should get a life and do something else.
