### PR TITLE
Bug fix unicode hosts

### DIFF
--- a/lib/term/terminal.py
+++ b/lib/term/terminal.py
@@ -19,8 +19,9 @@ class AutoSploitTerminal(object):
         self.tokens = tokens
         self.usage_path = lib.settings.USAGE_AND_LEGAL_PATH
         self.sep = "-" * 30
+        self.host_path = lib.settings.HOST_FILE
         try:
-            self.host_path = open(lib.settings.HOST_FILE).readlines()
+            open(lib.settings.HOST_FILE).readlines()
         except IOError:
             lib.output.warning("no hosts file present, you need to gather some hosts")
             self.host_path = lib.settings.HOST_FILE


### PR DESCRIPTION
This fixes issue #104. Appears the problem arose when you tried to add multiple single hosts, exit the tool, start it up again, and then view. My own testing showed it was a reliable bug, not dependent on the IP used:
[+] loading gathered hosts from '['1.1.1.1\n', '1.1.1.2\n', '1.1.1.3\n']'
Traceback (most recent call last):
  File "autosploit.py", line 5, in <module>
    main()
  File "/root/Null-AutoSploit/autosploit/main.py", line 58, in main
    terminal.terminal_main_display(loaded_exploits)
  File "/root/Null-AutoSploit/lib/term/terminal.py", line 273, in terminal_main_display
    self.view_gathered_hosts()
  File "/root/Null-AutoSploit/lib/term/terminal.py", line 73, in view_gathered_hosts
    with open(self.host_path) as hosts:
TypeError: coercing to Unicode: need string or buffer, list found

This pull request fixes the issue:

root@autosploit# 5
------------------------------
[+] loading gathered hosts from '/root/AutoSploit/hosts.txt'
[+] 1.1.1.1
[+] 1.1.1.2
[+] 1.1.1.3