### PR TITLE
exploit_gathered_hosts() fixed

### DIFF
--- a/lib/term/terminal.py
+++ b/lib/term/terminal.py
@@ -170,7 +170,7 @@ class AutoSploitTerminal(object):
         ruby_exec = False
         msf_path = None
         if hosts is None:
-            host_file = self.host_path
+            host_file = open(self.host_path).readlines()
         else:
             host_file = open(hosts).readlines()
         if not lib.settings.check_for_msf():


### PR DESCRIPTION
Looks like my last PR forgot to include the change to exploit_gathered_hosts(). It was trying to parse the path to the file as a list of hosts instead of the _contents_ of the file as the list of hosts. 

I changed AutoSploitTerminal.exploit_gathered_hosts() in lib/term/terminal.py to read the contents of the file itself instead of relying on __init__ to do it. 

Let me know if there is something I missed.

Thanks-