### PR TITLE
fixed check_for_msf() to check in $PATH

### DIFF
--- a/lib/settings.py
+++ b/lib/settings.py
@@ -178,10 +178,9 @@ def cmdline(command):
 
 def check_for_msf():
     """
-    check the ENV PATH for msfconsole.
-    Returns None if executable not found
+    check the ENV PATH for msfconsole
     """
-    return distutils.spawn.find_executable("msfconsole")
+    return os.getenv("msfconsole", False) or distutils.spawn.find_executable("msfconsole")
 
 def logo():
     """

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -6,6 +6,7 @@ import random
 import platform
 import getpass
 import tempfile
+import distutils.spawn
 # import subprocess
 
 import psutil
@@ -177,9 +178,10 @@ def cmdline(command):
 
 def check_for_msf():
     """
-    check the ENV PATH for msfconsole
+    check the ENV PATH for msfconsole.
+    Returns None if executable not found
     """
-    return os.getenv("msfconsole", False)
+    return distutils.spawn.find_executable("msfconsole")
 
 def logo():
     """


### PR DESCRIPTION
Changed the check_for_msf() function to search the $PATH for the msfconsole executable. It previously was searching for an environment variable named 'msfconsole'. 