### PR TITLE
Cmdline Whitelist Feature

### DIFF
--- a/lib/cmdline/cmd.py
+++ b/lib/cmdline/cmd.py
@@ -67,6 +67,8 @@ class AutoSploitParser(argparse.ArgumentParser):
                           help="pass the path to your framework if it is not in your ENV PATH")
         misc.add_argument("--ethics", action="store_true", dest="displayEthics",
                           help=argparse.SUPPRESS)  # easter egg!
+        misc.add_argument("--whitelist", metavar="PATH", dest="whitelist",
+                             help="only exploit hosts listed in the whitelist file")
         opts = parser.parse_args()
         return opts
 
@@ -160,10 +162,13 @@ class AutoSploitParser(argparse.ArgumentParser):
                 keys["censys"][1], keys["censys"][0], opt.searchQuery, proxy=headers[0], agent=headers[1]
             ).censys()
         if opt.startExploit:
+            hosts = open(lib.settings.HOST_FILE).readlines()
+            if opt.whitelist:
+                hosts = lib.exploitation.exploiter.whitelist_wash(hosts, whitelist_file=opt.whitelist)
             lib.exploitation.exploiter.AutoSploitExploiter(
                 opt.msfConfig,
                 loaded_modules,
-                open(lib.settings.HOST_FILE).readlines(),
+                hosts,
                 ruby_exec=opt.rubyExecutableNeeded,
                 msf_path=opt.pathToFramework
             ).start_exploit()

--- a/lib/exploitation/exploiter.py
+++ b/lib/exploitation/exploiter.py
@@ -1,6 +1,22 @@
 import lib.settings
 import lib.output
 
+def whitelist_wash(hosts, whitelist_file):
+    """
+    remove IPs from hosts list that do not appear in WHITELIST_FILE
+    """
+    whitelist_hosts = open(whitelist_file).readlines()
+    lib.output.info('Found {} entries in whitelist.txt, scrubbing'.format(str(len(whitelist_hosts))))
+    washed_hosts = []
+    #return supplied hosts if whitelist file is empty
+    if len(whitelist_hosts) == 0:
+        return hosts
+    else:
+        for host in hosts:
+            if host in whitelist_hosts:
+                washed_hosts.append(host)
+
+    return washed_hosts
 
 class AutoSploitExploiter(object):
 

--- a/lib/term/terminal.py
+++ b/lib/term/terminal.py
@@ -171,13 +171,13 @@ class AutoSploitTerminal(object):
         msf_path = None
         whitelist_file = lib.output.prompt("specify full path to a whitelist file, otherwise hit enter", lowercase=False)
         if hosts is None:
-            if whitelist_file is not "":
+            if whitelist_file is not "" and not whitelist_file.isspace():
                 # If whitelist is specified, return a washed hosts list
                 host_file = lib.exploitation.exploiter.whitelist_wash(open(self.host_path).readlines(), whitelist_file)
             else:
                 host_file = open(self.host_path).readlines()
         else:
-            if whitelist_file is not "":
+            if whitelist_file is not "" and not whitelist_file.isspace():
                 # If whitelist is specified, return a washed hosts list
                 host_file = lib.exploitation.exploiter.whitelist_wash(open(hosts).readlines(), whitelist_file)
             else:

--- a/lib/term/terminal.py
+++ b/lib/term/terminal.py
@@ -169,10 +169,19 @@ class AutoSploitTerminal(object):
         """
         ruby_exec = False
         msf_path = None
+        whitelist_file = lib.output.prompt("specify full path to a whitelist file, otherwise hit enter", lowercase=False)
         if hosts is None:
-            host_file = open(self.host_path).readlines()
+            if whitelist_file is not "":
+                # If whitelist is specified, return a washed hosts list
+                host_file = lib.exploitation.exploiter.whitelist_wash(open(self.host_path).readlines(), whitelist_file)
+            else:
+                host_file = open(self.host_path).readlines()
         else:
-            host_file = open(hosts).readlines()
+            if whitelist_file is not "":
+                # If whitelist is specified, return a washed hosts list
+                host_file = lib.exploitation.exploiter.whitelist_wash(open(hosts).readlines(), whitelist_file)
+            else:
+                host_file = open(hosts).readlines()
         if not lib.settings.check_for_msf():
             msf_path = lib.output.prompt(
                 "it appears that MSF is not in your PATH, provide the full path to msfconsole"


### PR DESCRIPTION
This PR includes the whitelist_wash() function, the cmdline argument, as well as the modification for the exploiter object call. If there is a more preferred way of implementing this feature, let me know. Currently it only works via cmdline, I'm planning on adding options to the interactive prompt next.

I originally thought of implementing this as a default file with its path specified in lib.settings (like the hosts file) but thought it would be better if it required the user to specify at run time.