### PR TITLE
Module Loading Prompt Prompt to load fuzzers/exploits

### DIFF
--- a/autosploit/main.py
+++ b/autosploit/main.py
@@ -69,17 +69,38 @@ def main():
                     )
                 )
 
+
     if len(sys.argv) > 1:
         info("attempting to load API keys")
         loaded_tokens = load_api_keys()
         AutoSploitParser().parse_provided(opts)
+
         misc_info("checking if there are multiple exploit files")
-        loaded_exploits = load_exploits(EXPLOIT_FILES_PATH)
+
+        modules_to_load = []
+        if opts.runExploits:
+            modules_to_load += ["exploits"]
+        if opts.runFuzzers:
+            modules_to_load += ["fuzzers"]
+
+        loaded_exploits = load_exploits(EXPLOIT_FILES_PATH, modules_to_load)
         AutoSploitParser().single_run_args(opts, loaded_tokens, loaded_exploits)
     else:
         warning("no arguments have been parsed, defaulting to terminal session. press 99 to quit and help to get help")
+
         misc_info("checking if there are multiple exploit files")
-        loaded_exploits = load_exploits(EXPLOIT_FILES_PATH)
+
+        load_exploit_modules = prompt("Use stored exploits MSF modules? [y/N]", lowercase=False)
+        load_fuzzers_modules = prompt("Use stored fuzzers MSF modules? [y/N]", lowercase=False)
+
+        modules_to_load = []
+        if load_exploit_modules.lower().startswith('y'):
+            modules_to_load += ["exploits"]
+        if load_fuzzers_modules.lower().startswith('y'):
+            modules_to_load += ["fuzzers"]
+
+        loaded_exploits = load_exploits(EXPLOIT_FILES_PATH, modules_to_load)
+
         info("attempting to load API keys")
         loaded_tokens = load_api_keys()
         terminal = AutoSploitTerminal(loaded_tokens)

--- a/etc/json/default_modules.json
+++ b/etc/json/default_modules.json
@@ -263,7 +263,9 @@
      "exploit/windows/smb/ipass_pipe_exec",
      "exploit/windows/smb/smb_relay",
      "auxiliary/sqli/oracle/jvm_os_code_10g",
-     "auxiliary/sqli/oracle/jvm_os_code_11g",
+     "auxiliary/sqli/oracle/jvm_os_code_11g"
+     ],
+  "fuzzers": [
      "auxiliary/fuzzers/dns/dns_fuzzer",
      "auxiliary/fuzzers/ftp/client_ftp",
      "auxiliary/fuzzers/ftp/ftp_pre_post",

--- a/lib/cmdline/cmd.py
+++ b/lib/cmdline/cmd.py
@@ -59,13 +59,9 @@ class AutoSploitParser(argparse.ArgumentParser):
                              help="set the configuration for MSF (IE -C default 127.0.0.1 8080)")
         exploit.add_argument("-e", "--exploit", action="store_true", dest="startExploit",
                              help="start exploiting the already gathered hosts")
-        exploit.add_argument("--load-exploits",
-                             action="store_true",
-                             dest="runExploits",
+        exploit.add_argument("--load-exploits", action="store_true", dest="runExploits",
                              help="Use this flag to run the stored JSON exploits MSF modules.")
-        exploit.add_argument("--load-fuzzers",
-                             action="store_true",
-                             dest="runFuzzers",
+        exploit.add_argument("--load-fuzzers", action="store_true", dest="runFuzzers",
                              help="Use this flag to run the stored JSON fuzzers MSF modules.")
 
         misc = parser.add_argument_group("misc arguments", "arguments that don't fit anywhere else")

--- a/lib/cmdline/cmd.py
+++ b/lib/cmdline/cmd.py
@@ -59,6 +59,14 @@ class AutoSploitParser(argparse.ArgumentParser):
                              help="set the configuration for MSF (IE -C default 127.0.0.1 8080)")
         exploit.add_argument("-e", "--exploit", action="store_true", dest="startExploit",
                              help="start exploiting the already gathered hosts")
+        exploit.add_argument("--load-exploits",
+                             action="store_true",
+                             dest="runExploits",
+                             help="Use this flag to run the stored JSON exploits MSF modules.")
+        exploit.add_argument("--load-fuzzers",
+                             action="store_true",
+                             dest="runFuzzers",
+                             help="Use this flag to run the stored JSON fuzzers MSF modules.")
 
         misc = parser.add_argument_group("misc arguments", "arguments that don't fit anywhere else")
         misc.add_argument("--ruby-exec", action="store_true", dest="rubyExecutableNeeded",

--- a/lib/jsonize.py
+++ b/lib/jsonize.py
@@ -44,7 +44,7 @@ def load_exploits(path, nodes):
         # the road
         _json = json.loads(exploit_file.read())
         for node in nodes:
-            for item in _json[node]:
+            for item in _json.get(node, []):
                 # so we'll reload it into a ascii string before we save it into the file
                 retval.append(str(item))
     return retval

--- a/lib/jsonize.py
+++ b/lib/jsonize.py
@@ -20,7 +20,7 @@ def random_file_name(acceptable=string.ascii_letters, length=7):
     return ''.join(list(retval))
 
 
-def load_exploits(path, node="exploits"):
+def load_exploits(path, nodes):
     """
     load exploits from a given path, depending on how many files are loaded into
     the beginning `file_list` variable it will display a list of them and prompt
@@ -43,9 +43,10 @@ def load_exploits(path, node="exploits"):
         # loading it like this has been known to cause Unicode issues later on down
         # the road
         _json = json.loads(exploit_file.read())
-        for item in _json[node]:
-            # so we'll reload it into a ascii string before we save it into the file
-            retval.append(str(item))
+        for node in nodes:
+            for item in _json[node]:
+                # so we'll reload it into a ascii string before we save it into the file
+                retval.append(str(item))
     return retval
 
 


### PR DESCRIPTION
The MSF fuzzer modules are taking forever and sometimes never complete, which is an issue if multiple hosts are fed to AutoSploit.

Added two flags to determine which exploits to run.
The idea can easily be expanded to allow certain categories of exploit to run.

The code in 'main.py' would benefit to be refactored altogether, I'm just submitting a simple version that works.