### PR TITLE
Happy new year

### DIFF
--- a/.github/.translations/README-de.md
+++ b/.github/.translations/README-de.md
@@ -152,7 +152,7 @@ misc arguments:
 Falls du AutoSploit auf einem System mit macOS ausführen willst, musst du das Programm trotz der Kompatibilität mit macOS in einer virtuellen Maschine ausführen, sodass es erfolgreich ausgeführt werden kann. Um dies zu tun, sind folgende Schritte nötig;
 
 ```bash
-sudo -s << '_EOF' 
+sudo -s << '_EOF'
 pip2 install virtualenv --user
 git clone https://github.com/NullArray/AutoSploit.git
 virtualenv <PFAD-ZU-DEINER-ENV>
@@ -173,12 +173,13 @@ AutoSploit benötigt die folgenden Python 2.7 Module:
 ```
 requests
 psutil
+beautifulsoup4
 ```
 
 Wenn dir auffällt, dass du diese nicht installiert hast, kannst du sie über Pip installieren, wie nachfolgend gezeigt.
 
 ```bash
-pip install requests psutil
+pip install requests psutil beautifulsoup4
 ```
 
 oder

--- a/.github/.translations/README-fr.md
+++ b/.github/.translations/README-fr.md
@@ -3,7 +3,7 @@
 Comme vous pouvez l'imaginer au vu du nom de ce projet, AutoSploit automatise l'exploitation d'hôtes distantes connectées à internet. Les adresses des hôtes à attaquer sont collectées automatiquement grâce à l'aide de Shodan, Censys et Zoomeye. Vous pouvez également utiliser vos propres listes de cibles.
 Les modules Metasploit disponibles ont été sélectionnés afin de faciliter l'obtention d'exécution de code à distance ( Remote Code Execution, ou RCE ), qui permettent ensuite de créer des sessions terminal inversées ( reverse shell ) ou meterpreter ( via metasploit ).
 
-**Ne soyez pas stupides** 
+**Ne soyez pas stupides**
 
 Recevoir les connexions de vos victimes directement sur votre ordinateur n'est pas vraiment une bonne idée. Vous devriez considérer l'option de dépenser quelques euros dans un VPS ( ou VPN ).
 
@@ -127,12 +127,13 @@ AutoSploit exige la présence des modules Python2.7 suivants.
 ```
 requests
 psutil
+beautifulsoup4
 ```
 
 Si vous ne les avez pas, vous pouvez les installer avec les commandes ci-dessous ( dans le dossier d'AutoSploit ):
 
 ```bash
-pip install requests psutil
+pip install requests psutil beautifulsoup4
 ```
 
 ou

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ uid.p
 etc/tokens/*
 autosploit_out/*
 venv/*
+etc/json/*

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ uid.p
 etc/tokens/*
 autosploit_out/*
 venv/*
-etc/json/*

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -1,17 +1,23 @@
 FROM kalilinux/kali-linux-docker
 
-RUN apt update && apt install -y postgresql \
-								 apache2 \
-								 python-pip \
-								 python-dev \
-								 build-essential \
-								 git \
-								 metasploit-framework
+RUN apt update \
+ && apt install -y \
+			apache2 \
+			build-essential \
+			git \
+			metasploit-framework \
+			postgresql \
+			python-dev \
+			python-pip
 
-RUN git clone https://github.com/NullArray/AutoSploit.git && pip install requests psutil
+RUN git clone https://github.com/NullArray/AutoSploit.git \
+ && pip install -r AutoSploit/requirements.txt
+
 COPY database.yml /root/.msf4/database.yml
+
 WORKDIR AutoSploit
+
 EXPOSE 80 443 4444
 
 ENTRYPOINT ["python", "autosploit.py"]
-#ENTRYPOINT ["bash"]
+# ENTRYPOINT ["bash"]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ sudo -s << EOF
 git clone https://github.com/NullArray/AutoSploit.git
 cd AutoSploit
 chmod +x install.sh
-./installsh
+./install.sh
 cd AutoSploit/Docker
 docker network create -d bridge haknet
 docker run --network haknet --name msfdb -e POSTGRES_PASSWORD=s3cr3t -d postgres
@@ -64,7 +64,7 @@ chmod +x install.sh
 ./install.sh
 ```
 
-If you want to run AutoSploit on a macOS system, AutoSploit is compatible with macOS, however, you have to be inside a virtual environment for it to run successfully. To do this, do the following;
+AutoSploit is compatible with macOS, however, you have to be inside a virtual environment for it to run successfully. In order to accomplish this employ/perform the below operations via the terminal or in the form of a shell script.
 
 ```bash
 sudo -s << '_EOF'
@@ -149,21 +149,6 @@ misc arguments:
   --whitelist PATH      only exploit hosts listed in the whitelist file
 ```
 
-If you want to run AutoSploit on a macOS system, AutoSploit is compatible with macOS, however, you have to be inside a virtual environment for it to run successfully. To do this, do the following;
-
-```bash
-sudo -s << '_EOF'
-pip2 install virtualenv --user
-git clone https://github.com/NullArray/AutoSploit.git
-virtualenv <PATH-TO-YOUR-ENV>
-source <PATH-TO-YOUR-ENV>/bin/activate
-cd <PATH-TO-AUTOSPLOIT>
-pip2 install -r requirements.txt
-chmod +x install.sh
-./install.sh
-python autosploit.py
-_EOF
-```
 
 ## Dependencies
 _Note_: All dependencies should be installed using the above installation method, however, if you find they are not:
@@ -173,13 +158,12 @@ AutoSploit depends on the following Python2.7 modules.
 ```
 requests
 psutil
-beautifulsoup4
 ```
 
 Should you find you do not have these installed get them with pip like so.
 
 ```bash
-pip install requests psutil beautifulsoup4
+pip install requests psutil
 ```
 
 or
@@ -192,9 +176,11 @@ Since the program invokes functionality from the Metasploit Framework you need t
 
 ## Acknowledgements
 
-Special thanks to [Ekultek](https://github.com/Ekultek) without whoms contributions to the project version 2.0 would have been a lot less spectacular.
+Special thanks to [Ekultek](https://github.com/Ekultek) without whoms contributions to the project, version 2.0 would have been a lot less spectacular.
 
-And thanks to [Khast3x](https://github.com/khast3x) for setting up Docker support.
+Thanks to [Khast3x](https://github.com/khast3x) for setting up Docker support.
+
+Last but certainly not least. Thanks to all who have submitted Pull Requests, bug reports, useful and productive contributions in general.  
 
 ### Active Development
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ misc arguments:
 If you want to run AutoSploit on a macOS system, AutoSploit is compatible with macOS, however, you have to be inside a virtual environment for it to run successfully. To do this, do the following;
 
 ```bash
-sudo -s << '_EOF' 
+sudo -s << '_EOF'
 pip2 install virtualenv --user
 git clone https://github.com/NullArray/AutoSploit.git
 virtualenv <PATH-TO-YOUR-ENV>
@@ -173,12 +173,13 @@ AutoSploit depends on the following Python2.7 modules.
 ```
 requests
 psutil
+beautifulsoup4
 ```
 
 Should you find you do not have these installed get them with pip like so.
 
 ```bash
-pip install requests psutil
+pip install requests psutil beautifulsoup4
 ```
 
 or

--- a/api_calls/censys.py
+++ b/api_calls/censys.py
@@ -24,7 +24,7 @@ class CensysAPIHook(object):
         self.host_file = HOST_FILE
         self.save_mode = save_mode
 
-    def censys(self):
+    def search(self):
         """
         connect to the Censys API and pull all IP addresses from the provided query
         """

--- a/api_calls/shodan.py
+++ b/api_calls/shodan.py
@@ -25,7 +25,7 @@ class ShodanAPIHook(object):
         self.host_file = HOST_FILE
         self.save_mode = save_mode
 
-    def shodan(self):
+    def search(self):
         """
         connect to the API and grab all IP addresses associated with the provided query
         """

--- a/api_calls/zoomeye.py
+++ b/api_calls/zoomeye.py
@@ -54,7 +54,7 @@ class ZoomEyeAPIHook(object):
         token = json.loads(req.content)
         return token
 
-    def zoomeye(self):
+    def search(self):
         """
         connect to the API and pull all the IP addresses that are associated with the
         given query

--- a/autosploit/main.py
+++ b/autosploit/main.py
@@ -117,8 +117,8 @@ def main():
             loaded_exploits = load_exploits(EXPLOIT_FILES_PATH)
             info("attempting to load API keys")
             loaded_tokens = load_api_keys()
-            terminal = AutoSploitTerminal(loaded_tokens)
-            terminal.terminal_main_display(loaded_exploits)
+            terminal = AutoSploitTerminal(loaded_tokens, loaded_exploits)
+            terminal.terminal_main_display(loaded_tokens)
     except Exception as e:
         import traceback
 

--- a/autosploit/main.py
+++ b/autosploit/main.py
@@ -69,9 +69,7 @@ def main():
                     )
                     if choice.lower().startswith("y"):
                         try:
-                            if "darwin" in platform_running.lower():
-                                cmdline("{} darwin".format(START_SERVICES_PATH))
-                            elif "linux" in platform_running.lower():
+                            if "linux" in platform_running.lower():
                                 cmdline("{} linux".format(START_SERVICES_PATH))
                             else:
                                 close("your platform is not supported by AutoSploit at this time", status=2)

--- a/autosploit/main.py
+++ b/autosploit/main.py
@@ -109,10 +109,6 @@ def main():
 
             AutoSploitParser().single_run_args(opts, loaded_tokens, loaded_exploits)
         else:
-            warning(
-                "no arguments have been parsed, defaulting to terminal session. "
-                "press 99 to quit and type `help` to view the help menus"
-            )
             misc_info("checking if there are multiple exploit files")
             loaded_exploits = load_exploits(EXPLOIT_FILES_PATH)
             info("attempting to load API keys")

--- a/etc/scripts/start_services.sh
+++ b/etc/scripts/start_services.sh
@@ -11,21 +11,10 @@ function startPostgreSQLLinux () {
   sudo systemctl start postgresql > /dev/null 2>&1
 }
 
-function startApacheOSX () {
-  sudo apachectl start > /dev/null 2>&1
-}
-
-function startPostgreSQLOSX () {
-  brew services restart postgresql > /dev/null 2>&1
-}
-
 function main () {
   if [ $1 == "linux" ]; then
     startApacheLinux;
     startPostgreSQLLinux;
-  elif [ $1 == "darwin" ]; then
-    startApacheOSX;
-    startPostgreSQLOSX;
   else
     echo "[*] invalid operating system";
   fi

--- a/etc/text_files/gen
+++ b/etc/text_files/gen
@@ -1,0 +1,8 @@
+usage of AutoSploit for attacking targets without prior mutual consent is illegal in pretty much every sense of the word. it is the end user's responsibility to obey all applicable local, state, and federal laws. developers assume no liability and are not responsible for any misuse or damage caused by this program. please take these considerations into mind:
+
+ - use AutoSploit on a VPS through a proxy or Tor
+ - keep calm and wipe the logs or use tools to do so
+ - never connect from your local IP address
+ - keep a low profile, the point of hacking is not to get caught
+
+we do not condone hacking of any sort, the above are tips to keep in mind for ethical purposes. having said that, knowledge is not illegal, and anybody that tells you learning is wrong is a fool. get as much out of this program as we got from writing it.

--- a/etc/text_files/gen
+++ b/etc/text_files/gen
@@ -1,8 +1,18 @@
-usage of AutoSploit for attacking targets without prior mutual consent is illegal in pretty much every sense of the word. it is the end user's responsibility to obey all applicable local, state, and federal laws. developers assume no liability and are not responsible for any misuse or damage caused by this program. please take these considerations into mind:
+Usage of AutoSploit for attacking targets without prior mutual consent is illegal in pretty much every sense of the word. It is the
+end user's responsibility to obey all applicable local, state, and federal laws. Developers assume no liability and are not responsible
+for any misuse or damage caused by this program or any component thereof. 
 
- - use AutoSploit on a VPS through a proxy or Tor
- - keep calm and wipe the logs or use tools to do so
- - never connect from your local IP address
- - keep a low profile, the point of hacking is not to get caught
+Developers do not encourage nor condone any illegal activity;
 
-we do not condone hacking of any sort, the above are tips to keep in mind for ethical purposes. having said that, knowledge is not illegal, and anybody that tells you learning is wrong is a fool. get as much out of this program as we got from writing it.
+In OffSec/RedTeam engagements it is important however to mind your operational security. With that in mind, please consider the following:
+
+ - Use AutoSploit on a VPS through a proxy(chain) or Tor
+ - Keep calm and wipe/data-poison the logs or use tools to do so
+ - Never connect from your local IP address
+ - Keep a low profile, AutoSploit is loud
+
+
+In closing, knowledge is not illegal and anybody that tells you learning is wrong is a fool.
+Get as much out of this program as we got from writing it. Remember though, common sense and a sense of ethics go a long way.
+
+Thank you.

--- a/lib/banner.py
+++ b/lib/banner.py
@@ -1,7 +1,7 @@
 import os
 import random
 
-VERSION = "2.2.4"
+VERSION = "2.2.5"
 
 
 def banner_1(line_sep="#--", space=" " * 30):

--- a/lib/banner.py
+++ b/lib/banner.py
@@ -1,7 +1,7 @@
 import os
 import random
 
-VERSION = "2.2.3"
+VERSION = "2.2.4"
 
 
 def banner_1(line_sep="#--", space=" " * 30):

--- a/lib/banner.py
+++ b/lib/banner.py
@@ -1,7 +1,7 @@
 import os
 import random
 
-VERSION = "2.2.5"
+VERSION = "3.0"
 
 
 def banner_1(line_sep="#--", space=" " * 30):

--- a/lib/cmdline/cmd.py
+++ b/lib/cmdline/cmd.py
@@ -141,7 +141,25 @@ class AutoSploitParser(argparse.ArgumentParser):
                     "You should take this ethical lesson into consideration "
                     "before you continue with the use of this tool:\n\n{}\n".format(ethic))
         if opt.downloadModules is not None:
-            print "downloading MODULES!"
+            import re
+
+            modules_to_download = opt.downloadModules
+            links_list = "{}/etc/text_files/links.txt".format(lib.settings.CUR_DIR)
+            possibles = open(links_list).readlines()
+            for module in modules_to_download:
+                searcher = re.compile("{}".format(module))
+                for link in possibles:
+                    if searcher.search(link) is not None:
+                        filename = lib.settings.download_modules(link.strip())
+                        download_filename = "{}.json".format(link.split("/")[-1].split(".")[0])
+                        download_path = "{}/etc/json".format(os.getcwd())
+                        current_files = os.listdir(download_path)
+                        if download_filename not in current_files:
+                            full_path = "{}/{}".format(download_path, download_filename)
+                            lib.jsonize.text_file_to_dict(filename, filename=full_path)
+                            lib.output.info("downloaded into: {}".format(download_path))
+                        else:
+                            lib.output.warning("file already downloaded, skipping")
         if opt.exploitList:
             try:
                 lib.output.info("converting {} to JSON format".format(opt.exploitList))

--- a/lib/cmdline/cmd.py
+++ b/lib/cmdline/cmd.py
@@ -187,33 +187,33 @@ class AutoSploitParser(argparse.ArgumentParser):
                 keys["censys"][1], keys["censys"][0],
                 opt.searchQuery, proxy=headers[0], agent=headers[1],
                 save_mode=search_save_mode
-            ).censys()
+            ).search()
         if opt.searchZoomeye:
             lib.output.info(single_search_msg.format("Zoomeye"))
             api_searches[0](
                 opt.searchQuery, proxy=headers[0], agent=headers[1],
                 save_mode=search_save_mode
-            ).zoomeye()
+            ).search()
         if opt.searchShodan:
             lib.output.info(single_search_msg.format("Shodan"))
             api_searches[1](
                 keys["shodan"][0], opt.searchQuery, proxy=headers[0], agent=headers[1],
                 save_mode=search_save_mode
-            ).shodan()
+            ).search()
         if opt.searchAll:
             lib.output.info("searching all search engines in order")
             api_searches[0](
                 opt.searchQuery, proxy=headers[0], agent=headers[1],
                 save_mode=search_save_mode
-            ).zoomeye()
+            ).search()
             api_searches[1](
                 keys["shodan"][0], opt.searchQuery, proxy=headers[0], agent=headers[1],
                 save_mode=search_save_mode
-            ).shodan()
+            ).search()
             api_searches[2](
                 keys["censys"][1], keys["censys"][0], opt.searchQuery, proxy=headers[0], agent=headers[1],
                 save_mode=search_save_mode
-            ).censys()
+            ).search()
         if opt.startExploit:
             hosts = open(lib.settings.HOST_FILE).readlines()
             if opt.whitelist:

--- a/lib/creation/issue_creator.py
+++ b/lib/creation/issue_creator.py
@@ -1,4 +1,5 @@
 import re
+import os
 import sys
 import json
 import platform
@@ -165,5 +166,9 @@ def request_issue_creation(path, arguments, error_message):
             lib.output.error(
                 "someone has already created this issue here: {}".format(find_url(identifier))
             )
+        try:
+            os.remove(path)
+        except:
+            pass
     else:
         lib.output.info("the issue has been logged to a file in path: '{}'".format(path))

--- a/lib/exploitation/exploiter.py
+++ b/lib/exploitation/exploiter.py
@@ -131,14 +131,14 @@ class AutoSploitExploiter(object):
                     "set rhost {rhost}\n"
                     "set rhosts {rhosts}\n"
                     "run -z\n"
-                    "exit\n"
+                    "exit -y\n"
                 )
 
-                module_name=mod.strip()
-                workspace=self.configuration[0]
-                lhost=self.configuration[1]
-                lport=self.configuration[2]
-                rhost=host.strip()
+                module_name = mod.strip()
+                workspace = self.configuration[0]
+                lhost = self.configuration[1]
+                lport = self.configuration[2]
+                rhost = host.strip()
 
                 current_rc_script_path = path.join(current_host_path, mod.replace("/", '-').strip())
                 with open(current_rc_script_path, 'w') as f:

--- a/lib/exploitation/exploiter.py
+++ b/lib/exploitation/exploiter.py
@@ -78,7 +78,11 @@ class AutoSploitExploiter(object):
 
         today_printable = datetime.datetime.today().strftime("%Y-%m-%d_%Hh%Mm%Ss")
         current_run_path = path.join(lib.settings.RC_SCRIPTS_PATH, today_printable)
-        makedirs(current_run_path)
+        try:
+            makedirs(current_run_path)
+        except OSError:
+            current_run_path = path.join(lib.settings.RC_SCRIPTS_PATH, today_printable + "(1)")
+            makedirs(current_run_path)
 
         report_path = path.join(current_run_path, "report.csv")
         with open(report_path, 'w') as f:

--- a/lib/exploitation/exploiter.py
+++ b/lib/exploitation/exploiter.py
@@ -29,7 +29,7 @@ def whitelist_wash(hosts, whitelist_file):
                     washed_hosts.append(host)
 
         return washed_hosts
-    except Exception:
+    except IOError:
         lib.output.warning("unable to whitewash host list, does the file exist?")
         return hosts
 

--- a/lib/jsonize.py
+++ b/lib/jsonize.py
@@ -58,7 +58,7 @@ def load_exploits(path, node="exploits"):
             try:
                 selected_file = file_list[int(action) - 1]
                 selected = True
-            except Exception:
+            except Except:
                 lib.output.warning("invalid selection ('{}'), select from below".format(action))
                 selected = False
     else:

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -52,6 +52,7 @@ search/api/gather       Search the API's for hosts
 exit/quit               Exit the terminal session
 single                  Load a single host into the file
 tokens/reset            Reset API tokens if needed
+external                View loaded external commands
 help/?                  Display this help
 """
 

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -328,3 +328,23 @@ def save_error_to_file(error_info, error_message, error_class):
             "Traceback (most recent call):\n " + error_info.strip() + "\n{}: {}".format(error_class, error_message)
         )
     return file_path
+
+
+def download_modules(link):
+    import re
+    import requests
+    import tempfile
+
+    lib.output.info('downloading: {}'.format(link))
+    retval = ""
+    req = requests.get(link)
+    content = req.content
+    split_data = content.split(" ")
+    searcher = re.compile("exploit/\w+/\w+")
+    storage_file = tempfile.NamedTemporaryFile(delete=False)
+    for item in split_data:
+        if searcher.search(item) is not None:
+            retval += item + "\n"
+    with open(storage_file.name, 'a+') as tmp:
+        tmp.write(retval)
+    return storage_file.name

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -161,7 +161,7 @@ def backup_host_file(current, path):
         os.makedirs(path)
     new_filename = "{}/hosts_{}_{}.txt".format(
         path,
-        lib.jsonize.random_file_name(length=17),
+        lib.jsonize.random_file_name(length=22),
         str(datetime.datetime.today()).split(" ")[0]
     )
     shutil.copyfile(current, new_filename)

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -51,6 +51,7 @@ exploit/run/attack      Run the exploits on the already gathered hosts
 search/api/gather       Search the API's for hosts
 exit/quit               Exit the terminal session
 single                  Load a single host into the file
+personal/custom         Load a custom host file
 tokens/reset            Reset API tokens if needed
 external                View loaded external commands
 help/?                  Display this help

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -6,6 +6,7 @@ import random
 import platform
 import getpass
 import tempfile
+import readline
 import distutils.spawn
 from subprocess import (
     PIPE,
@@ -16,8 +17,55 @@ import psutil
 
 import lib.output
 import lib.banner
+import lib.jsonize
 
+
+class AutoSploitCompleter(object):
+
+    """
+    object to create an auto completer for the terminal
+    """
+
+    def __init__(self, opts):
+        self.opts = sorted(opts)
+        self.possibles = []
+
+    def complete_text(self, text, state):
+        if state == 0:
+            if text:
+                self.possibles = [m for m in self.opts if m.startswith(text)]
+            else:
+                self.possibles = self.opts[:]
+        try:
+            return self.possibles[state]
+        except IndexError:
+            return None
+
+
+TERMINAL_HELP_MESSAGE = """
+COMMAND:                SUMMARY:
+---------               --------
+view/show               Show the already gathered hosts
+mem[ory]/history        Display the command history
+exploit/run/attack      Run the exploits on the already gathered hosts
+search/api/gather       Search the API's for hosts
+exit/quit               Exit the terminal session
+single                  Load a single host into the file
+tokens/reset            Reset API tokens if needed
+help/?                  Display this help
+"""
+
+# current directory
 CUR_DIR = "{}".format(os.getcwd())
+
+# home
+HOME = "{}/.autosploit_home".format(os.path.expanduser("~"))
+
+# backup the current hosts file
+HOST_FILE_BACKUP = "{}/backups".format(HOME)
+
+# autosploit command history file path
+HISTORY_FILE_PATH = "{}/.history".format(HOME)
 
 # path to the file containing all the discovered hosts
 HOST_FILE = "{}/hosts.txt".format(CUR_DIR)
@@ -49,7 +97,7 @@ DEFAULT_USER_AGENT = "AutoSploit/{} (Language=Python/{}; Platform={})".format(
 PLATFORM_PROMPT = "\n{}@\033[36mPLATFORM\033[0m$ ".format(getpass.getuser())
 
 # the prompt that will be used most of the time
-AUTOSPLOIT_PROMPT = "\n\033[31m{}\033[0m@\033[36mautosploit\033[0m# ".format(getpass.getuser())
+AUTOSPLOIT_PROMPT = "\033[31m{}\033[0m@\033[36mautosploit\033[0m# ".format(getpass.getuser())
 
 # all the paths to the API tokens
 API_KEYS = {
@@ -74,7 +122,7 @@ MSF_LAUNCHED = False
 TOKEN_PATH = "{}/etc/text_files/auth.key".format(CUR_DIR)
 
 # location of error files
-ERROR_FILES_LOCATION = "{}/.autosploit_errors".format(os.path.expanduser("~"))
+ERROR_FILES_LOCATION = "{}/.autosploit_errors".format(HOME)
 
 # terminal options
 AUTOSPLOIT_TERM_OPTS = {
@@ -83,14 +131,58 @@ AUTOSPLOIT_TERM_OPTS = {
     99: "quit"
 }
 
+# global variable for the search animation
 stop_animation = False
 
 
-def validate_ip_addr(provided):
+def load_external_commands():
+    """
+    create a list of external commands from provided directories
+    """
+    paths = ["/bin", "/usr/bin"]
+    loaded_externals = []
+    for f in paths:
+        for cmd in os.listdir(f):
+            if not os.path.isdir("{}/{}".format(f, cmd)):
+                loaded_externals.append(cmd)
+    return loaded_externals
+
+
+def backup_host_file(current, path):
+    """
+    backup the current hosts file
+    """
+    import datetime
+    import shutil
+
+    if not os.path.exists(path):
+        os.makedirs(path)
+    new_filename = "{}/hosts_{}_{}.txt".format(
+        path,
+        lib.jsonize.random_file_name(length=17),
+        str(datetime.datetime.today()).split(" ")[0]
+    )
+    shutil.copyfile(current, new_filename)
+    return new_filename
+
+
+def auto_completer(keywords):
+    """
+    function to initialize the auto complete utility
+    """
+    completer = AutoSploitCompleter(keywords)
+    readline.set_completer(completer.complete_text)
+    readline.parse_and_bind('tab: complete')
+
+
+def validate_ip_addr(provided, home_ok=False):
     """
     validate an IP address to see if it is real or not
     """
-    not_acceptable = ("0.0.0.0", "127.0.0.1", "255.255.255.255")
+    if not home_ok:
+        not_acceptable = ("0.0.0.0", "127.0.0.1", "255.255.255.255")
+    else:
+        not_acceptable = ("255.255.255.255",)
     if provided not in not_acceptable:
         try:
             socket.inet_aton(provided)
@@ -186,7 +278,7 @@ def load_api_keys(unattended=False, path="{}/etc/tokens".format(CUR_DIR)):
     return api_tokens
 
 
-def cmdline(command):
+def cmdline(command, is_msf=True):
     """
     send the commands through subprocess
     """
@@ -200,7 +292,10 @@ def cmdline(command):
     stdout_buff = []
     for stdout_line in iter(proc.stdout.readline, b''):
         stdout_buff += [stdout_line.rstrip()]
-        print("(msf)>> {}".format(stdout_line).rstrip())
+        if is_msf:
+            print("(msf)>> {}".format(stdout_line).rstrip())
+        else:
+            print("{}".format(stdout_line).rstrip())
 
     return stdout_buff
 
@@ -331,6 +426,9 @@ def save_error_to_file(error_info, error_message, error_class):
 
 
 def download_modules(link):
+    """
+    download new module links
+    """
     import re
     import requests
     import tempfile
@@ -348,3 +446,18 @@ def download_modules(link):
     with open(storage_file.name, 'a+') as tmp:
         tmp.write(retval)
     return storage_file.name
+
+
+def find_similar(command, internal, external):
+    """
+    find commands similar to the one provided
+    """
+    retval = []
+    first_char = command[0]
+    for inter in internal:
+        if inter.startswith(first_char):
+            retval.append(inter)
+    for exter in external:
+        if exter.startswith(first_char):
+            retval.append(exter)
+    return retval

--- a/lib/term/terminal.py
+++ b/lib/term/terminal.py
@@ -274,7 +274,12 @@ class AutoSploitTerminal(object):
         option 3 must be provided
         """
         provided_host_file = lib.output.prompt("enter the full path to your host file", lowercase=False)
-        self.exploit_gathered_hosts(mods, hosts=provided_host_file)
+        if provided_host_file == "":
+            lib.output.error("you provided a blank hosts file, did you mean to?")
+            lib.output.info("defaulting to default hosts file (press CNTRL-C to go back and try again)")
+            self.exploit_gathered_hosts(mods, hosts=self.host_path)
+        else:
+            self.exploit_gathered_hosts(mods, hosts=provided_host_file)
 
     def terminal_main_display(self, loaded_mods):
         """

--- a/lib/term/terminal.py
+++ b/lib/term/terminal.py
@@ -61,9 +61,12 @@ class AutoSploitTerminal(object):
         self.modules = modules
         try:
             self.loaded_hosts = open(lib.settings.HOST_FILE).readlines()
-        except:
+        except IOError:
             lib.output.warning("no hosts file present")
-            self.loaded_hosts = []
+            self.loaded_hosts = open(lib.settings.HOST_FILE, "a+").readlines()
+
+    def __reload(self):
+        self.loaded_hosts = open(lib.settings.HOST_FILE).readlines()
 
     def reflect_memory(self, max_memory=100):
         """
@@ -551,6 +554,7 @@ class AutoSploitTerminal(object):
                                 else:
                                     lib.output.error("cannot reset {} API credentials".format(choice))
                         self.history.append(choice)
+                        self.__reload()
                 except KeyboardInterrupt:
                     lib.output.warning("use the `exit/quit` command to end terminal session")
             except IndexError:

--- a/lib/term/terminal.py
+++ b/lib/term/terminal.py
@@ -385,7 +385,7 @@ class AutoSploitTerminal(object):
 
         try:
             open("{}".format(file_path)).close()
-        except Exception:
+        except IOError:
             lib.output.error("file does not exist, check the path and try again")
             return
         lib.output.warning("overwriting hosts file with provided, and backing up current")

--- a/lib/term/terminal.py
+++ b/lib/term/terminal.py
@@ -240,7 +240,7 @@ class AutoSploitTerminal(object):
         """
         if len(self.loaded_hosts) != 0:
             for host in self.loaded_hosts:
-                lib.output.info(host)
+                lib.output.info(host.strip())
         else:
             lib.output.warning("currently no gathered hosts")
 


### PR DESCRIPTION
This pull request creates autosploit 3.0, new features include:
  - Complete rewrite of the terminal
  - Command history
  - Host file backups
  - Ability to reset API tokens
  - Allows users to run external commands from inside the autosploit terminal, automatically loads all commands from `/usr/bin` and `/bin`
  - The terminal now has it's own commands
  - The terminal now functions like an actual terminal, meaning that you run commands. For example to search shodan, censys, and zoomeye all at once: `search shodan,censys,zoomeye windows 10` will search all 3 api's for anything related to windows 10
  - Fixes issues #250 #240 #225 #224 #221 #219 and #213 

New help menu for terminal:
```
COMMAND:                SUMMARY:
---------               --------
view/show               Show the already gathered hosts
mem[ory]/history        Display the command history
exploit/run/attack      Run the exploits on the already gathered hosts
search/api/gather       Search the API's for hosts
exit/quit               Exit the terminal session
single                  Load a single host into the file
personal/custom         Load a custom host file
tokens/reset            Reset API tokens if needed
external                View loaded external commands
help/?                  Display this help
```