### PR TITLE
nmap scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ If you would like to contribute to the development of this project please be sur
 
 Please, also, be sure to read our [contribution standards](https://github.com/NullArray/AutoSploit/wiki/Development-information#contribution-standards) before sending pull requests
 
-If you need some help understanding the code, or want to chat with some other AutoSploit community members, feel free to join our [Discord server](https://discord.gg/9BeeZQk).
+If you need some help understanding the code, or want to chat with some other AutoSploit community members, feel free to join our [Discord server](https://discord.gg/DZe4zr2).
 
 ### Note
 

--- a/autosploit/main.py
+++ b/autosploit/main.py
@@ -132,4 +132,5 @@ def main():
         error_traceback = ''.join(traceback.format_tb(sys.exc_info()[2]))
         error_class = str(e.__class__).split(" ")[1].split(".")[1].strip(">").strip("'")
         error_file = save_error_to_file(str(error_traceback), str(e), error_class)
-        request_issue_creation(error_file, hide_sensitive(), str(e))
+        print error_traceback
+        # request_issue_creation(error_file, hide_sensitive(), str(e))

--- a/etc/text_files/nmap_opts.lst
+++ b/etc/text_files/nmap_opts.lst
@@ -105,4 +105,3 @@
 --send-eth/--send-ip
 --privileged
 --unprivileged
--V

--- a/lib/banner.py
+++ b/lib/banner.py
@@ -1,7 +1,7 @@
 import os
 import random
 
-VERSION = "3.1.5"
+VERSION = "4.0"
 
 
 def banner_1(line_sep="#--", space=" " * 30):

--- a/lib/settings.py
+++ b/lib/settings.py
@@ -72,14 +72,17 @@ HOST_FILE_BACKUP = "{}/backups".format(HOME)
 # autosploit command history file path
 HISTORY_FILE_PATH = "{}/.history".format(HOME)
 
-# we'll save the scans output for future use
-NMAP_XML_OUTPUT_BACKUP = "{}/nmap_scans".format(HOME)
+# we'll save the scans xml output for future use
+NMAP_XML_OUTPUT_BACKUP = "{}/nmap_scans/xml".format(HOME)
+
+# we'll dump the generated dict data into JSON and save it into a file
+NMAP_JSON_OUTPUT_BACKUP = "{}/nmap_scans/json".format(HOME)
 
 # regex to discover errors or warnings
 NMAP_ERROR_REGEX_WARNING = re.compile("^warning: .*", re.IGNORECASE)
 
 # possible options in nmap
-NMAP_OPTIONS_PATH = "{}/etc_text_files/nmap_opts.lst".format(CUR_DIR)
+NMAP_OPTIONS_PATH = "{}/etc/text_files/nmap_opts.lst".format(CUR_DIR)
 
 # possible paths for nmap
 NMAP_POSSIBLE_PATHS = (
@@ -321,7 +324,7 @@ def cmdline(command, is_msf=True):
            else:
                print("{}".format(stdout_line).rstrip())
     except OSError as e:
-        stdout_buff += "ERROR: " + e
+        stdout_buff += "ERROR: " + str(e)
 
     return stdout_buff
 

--- a/lib/term/terminal.py
+++ b/lib/term/terminal.py
@@ -715,8 +715,8 @@ class AutoSploitTerminal(object):
                             #     ports = choice_data_list[3]
                             # except IndexError:
                             #     ports = None
-
-                            self.do_nmap_scan(target, arguments)
+                            if "help" not in choice_data_list:
+                                self.do_nmap_scan(target, arguments)
                         self.history.append(choice)
                         self.__reload()
                 except KeyboardInterrupt:


### PR DESCRIPTION
 - implements nmap scanning operations in autosploit, so you can scan form within the local framework
 - fixes issue #1163 

Real life scanning example:
```
sudo python autosploit.py 

--+ Graffiti the world with exploits +--
--+             __   ____            +-- 
--+            / _\ / ___)           +--
--+           /    \\___ \           +--
--+           \_/\_/(____/           +--
--+            AutoSploit            +--
--+           NullArray/Eku          +--
--+              v(4.0)              +--
    
[+] welcome to autosploit, give us a little bit while we configure
[i] checking your running platform
[i] checking for disabled services
[i] checking if there are multiple exploit files
[+] total of 2 exploit files discovered for use, select one:
1. 'default_modules'
2. 'default_fuzzers'
root@autosploit# 1
[+] attempting to load API keys
[+] Shodan API token loaded from /Users/admin/bin/python/autosploit/etc/tokens/shodan.key
[+] Censys API token loaded from /Users/admin/bin/python/autosploit/etc/tokens/censys.key
[-] no arguments have been parsed at run time, dropping into terminal session. to get help type `help` to quit type `exit/quit` to get help on a specific command type `command help`
root@autosploit# nmap 10.0.1.23 -sV,--reason,-A,-vv,-T3,--dns-servers=1.1.1.1
[-] arguments that have a space in them most likely will not be processed correctly, (IE --dns-servers 1.1.1.1 will most likely cause issues)
[?] argument: '-vv' is not in the list of 'known' nmap arguments, do you want to use it anyways[y/N]: y
[?] argument: '-T3' is not in the list of 'known' nmap arguments, do you want to use it anyways[y/N]: y
[?] argument: '--dns-servers=1.1.1.1' is not in the list of 'known' nmap arguments, do you want to use it anyways[y/N]: y
[+] performing nmap scan on 10.0.1.23
[+] launching nmap scan against 10.0.1.23 (nmap -oX - 10.0.1.23 -sV --reason -A -vv -T3 --dns-servers=1.1.1.1)
[i] JSON data dumped to file: '/Users/admin/.autosploit_home/nmap_scans/json/10.0.1.23_FIKJNQtT.json'
------------------------------
{
    "status": {
        "state": "up", 
        "reason": "arp-response"
    }, 
    "uptime": {
        "seconds": "593322", 
        "lastboot": "Wed Aug 28 17:05:30 2019"
    }, 
    "addresses": {
        "mac": "6C:2B:59:84:35:A1", 
        "ipv4": "10.0.1.23"
    }, 
    "tcp": [
        {
            "product": "OpenSSH", 
            "state": "open", 
            "version": "7.4", 
            "name": "ssh", 
            "conf": "10", 
            "reason": "syn-ack", 
            "extrainfo": "protocol 2.0", 
            "port": "22", 
            "cpe": "cpe:/a:openbsd:openssh:7.4"
        }, 
       ...
    ], 
    "vendors": {}, 
    "hostnames": [
        {
            "hostname": null, 
            "host_type": null
        }
    ]
}
------------------------------
root@autosploit# nmap help

        Explanation:
        -----------
        Perform a nmap scan on a provided target, given that nmap is on your system.
        If nmap is not on your system, this will not work, you may also provide
        arguments known to nmap.

        Parameters:
        ----------
        :param target: the target to attack
        :param arguments: a string of arguments separated by a comma

        Command Format:
        --------------
        nmap[/mapper/mappy] TARGET [ARGUMENTS]

        Examples:
        --------
        nmap/mapper/mappy 10.0.1.1 -sV,--dns-servers 1.1.1.1,--reason,-A
        nmap 10.0.1.1/24
        
root@autosploit# 
```

