### PR TITLE
Dependancy update

### DIFF
--- a/.github/.translations/README-de.md
+++ b/.github/.translations/README-de.md
@@ -179,12 +179,6 @@ beautifulsoup4
 Wenn dir auffällt, dass du diese nicht installiert hast, kannst du sie über Pip installieren, wie nachfolgend gezeigt.
 
 ```bash
-pip install requests psutil beautifulsoup4
-```
-
-oder
-
-```bash
 pip install -r requirements.txt
 ```
 

--- a/.github/.translations/README-zh.md
+++ b/.github/.translations/README-zh.md
@@ -38,16 +38,16 @@ RCE选择了该工具提供的Metasploit模块。 您可以在本仓库的module
 
 AutoSploit依赖于以下Python2.7模块。
 
-```bash
-shodan
-blessings
+```
+requests
+psutil
+beautifulsoup4
 ```
 
 如果你发现你没有安装这些软件，就像这样用pip来获取它们。
 
 ```bash
-pip install shodan
-pip install blessings
+pip install -r requirements.txt
 ```
 由于程序调用了Metasploit框架的功能，所以你也需要安装它。 通过点击[这里](https://www.rapid7.com/products/metasploit/)从Rapid7获取它。
 

--- a/README.md
+++ b/README.md
@@ -155,15 +155,10 @@ AutoSploit depends on the following Python2.7 modules.
 ```
 requests
 psutil
+beautifulsoup4
 ```
 
 Should you find you do not have these installed get them with pip like so.
-
-```bash
-pip install requests psutil
-```
-
-or
 
 ```bash
 pip install -r requirements.txt

--- a/install.sh
+++ b/install.sh
@@ -12,13 +12,13 @@ echo "                                                                    ";
 function installDebian () {
     sudo apt-get update;
     sudo apt-get -y install git python2.7 python-pip postgresql apache2;
-    pip2 install requests psutil;
+    pip2 install -r requirements.txt;
     installMSF;
 }
 
 function installFedora () {
     sudo yum -y install git python-pip;
-    pip2 install requests psutil;
+    pip2 install -r requirements.txt;
     installMSF;
 }
 


### PR DESCRIPTION
Added `beautifulsoup4` dependency to README's which was introduced into the code at this [commit](https://github.com/NullArray/AutoSploit/commit/fe6e345f33fc75494a89a7dade12e571ad30372f)

I've also removed the `pip install dependancy1, dependancy2, etc` command from the README to prevent the same issue happening in the future (if the README.MD doesn't get updated with the requirements.txt)

Apart from the READMEs, the install.sh was updated to use requirements.txt instead of manual dependency listing.